### PR TITLE
netdev-tc-offloads: Properly get the block id on flow del/get

### DIFF
--- a/lib/netdev-tc-offloads.c
+++ b/lib/netdev-tc-offloads.c
@@ -1531,9 +1531,9 @@ netdev_tc_flow_get(struct netdev *netdev OVS_UNUSED,
         return -ifindex;
     }
 
-    VLOG_DBG_RL(&rl, "flow get (dev %s chain %d prio %d handle %d)",
-                netdev_get_name(dev), chain, prio, handle);
-    block_id = get_block_id_from_netdev(netdev);
+    block_id = get_block_id_from_netdev(dev);
+    VLOG_DBG_RL(&rl, "flow get (dev %s chain %d prio %d handle %d block_id %d)",
+                netdev_get_name(dev), chain, prio, handle, block_id);
     err = tc_get_flower(ifindex, chain, prio, handle, &flower, block_id);
     netdev_close(dev);
     if (err) {
@@ -1578,7 +1578,7 @@ netdev_tc_flow_del(struct netdev *netdev OVS_UNUSED,
         return -ifindex;
     }
 
-    block_id = get_block_id_from_netdev(netdev);
+    block_id = get_block_id_from_netdev(dev);
 
     if (stats) {
         memset(stats, 0, sizeof *stats);


### PR DESCRIPTION
Currnetly, when a tc flow is installed on a bond port using shared blocks,
we get these failures from the validator threads:

2019-03-17T10:02:58.919Z|13369|dpif(revalidator93)|WARN|system@ovs-system: failed to flow_del \
	(No such file or directory) ufid:ebe2888b-9886-4835-a42e-c2911f6af6e8 skb_priority(0),skb_mark(0),in_port(2), \
	packet_type(ns=0,id=0),eth(src=e4:11:22:33:44:71,dst=24:8a:07:88:28:12),eth_type(0x0806), [..]

The block id must be retrieved from the device we got by ufid lookup and
not from the input to the related function, fix that for flow del and get.

While here, add the block id to existing debug print.

Fixes: 88dcf2aa8234 ('netdev-provider: add class op to get block_id')
Change-Id: I6d72d69a2e844a959791f7d3b302019f57c34351
Signed-off-by: Or Gerlitz <ogerlitz@mellanox.com>
Signed-off-by: Paul Blakey <paulb@mellanox.com>
Reviewed-by: Roi Dayan <roid@mellanox.com>
Signed-off-by: Simon Horman <simon.horman@netronome.com>